### PR TITLE
make barrett division generic to all fixed-width-integer 

### DIFF
--- a/Tests/Arithmetics.swift
+++ b/Tests/Arithmetics.swift
@@ -373,6 +373,24 @@ class UInt256ArithmeticTests: XCTestCase {
         XCTAssertEqual(quotient, UInt256([0, 0, 0x8000000000000000, 0]))
     }
 
+    func testBarrettDivision64() {
+        for _ in 0..<100 {
+            let hi = arc4random64()
+            let lo = arc4random64()
+            let a = arc4random64()
+            let invH = UInt64.max / a
+            let rH = UInt64.max % a
+            var (invL, rL) = a.dividingFullWidth((high: rH, low: UInt64.max))
+            if rL == a - 1 {
+                invL = invL + 1
+            }
+            let (q, r) = a.dividingFullWidth((hi, lo), withPrecomputedInverse: (invH, invL))
+            let (q_, r_) = a.dividingFullWidth((hi, lo))
+            XCTAssertEqual(q_, q)
+            XCTAssertEqual(r_, r)
+        }
+    }
+
     func testBigIntModulo() {
         let a = UInt256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFEFFFFFC2F])
         let b = UInt256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFEFFFFFC2D])

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -62,4 +62,39 @@ class PerformanceTests: XCTestCase {
             }
         }
     }
+
+    func testBarrettDivisionPerf64() {
+        self.measure {
+            for _ in 0..<1000 {
+                let hi = arc4random64()
+                let lo = arc4random64()
+                let a = arc4random64()
+                let invH = UInt64.max / a
+                let rH = UInt64.max % a
+                var (invL, rL) = a.dividingFullWidth((high: rH, low: UInt64.max))
+                if rL == a - 1 {
+                    invL = invL + 1
+                }
+                let _ = a.dividingFullWidth((hi, lo), withPrecomputedInverse: (invH, invL))
+            }
+        }
+    }
+
+    // for comparison with above test
+    func testNativeDivisionPerf64() {
+        self.measure {
+            for _ in 0..<1000 {
+                let hi = arc4random64()
+                let lo = arc4random64()
+                let a = arc4random64()
+                let invH = UInt64.max / a
+                let rH = UInt64.max % a
+                var (invL, rL) = a.dividingFullWidth((high: rH, low: UInt64.max))
+                if rL == a - 1 {
+                    invL = invL + 1
+                }
+                let _ = a.dividingFullWidth((hi, lo))
+            }
+        }
+    }
 }

--- a/UInt256.xcodeproj/project.pbxproj
+++ b/UInt256.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		63650A421FF85FE90065405F /* UInt256.h in Headers */ = {isa = PBXBuildFile; fileRef = 636509E41FF859640065405F /* UInt256.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		636EA8E220131E07006A60DA /* UInt256+Divide&Conquer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636EA8E120131E07006A60DA /* UInt256+Divide&Conquer.swift */; };
 		636EA8E320131E07006A60DA /* UInt256+Divide&Conquer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636EA8E120131E07006A60DA /* UInt256+Divide&Conquer.swift */; };
-		636F8BF7201656B800F37750 /* UInt256+BarrettDivision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636F8BF6201656B800F37750 /* UInt256+BarrettDivision.swift */; };
-		636F8BF8201656B800F37750 /* UInt256+BarrettDivision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636F8BF6201656B800F37750 /* UInt256+BarrettDivision.swift */; };
+		636F8BF7201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636F8BF6201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift */; };
+		636F8BF8201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636F8BF6201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift */; };
 		637A1AC9202043C70013C247 /* UInt256.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63650A311FF85F960065405F /* UInt256.framework */; };
 		637A1ACF2020445C0013C247 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63123F5B2012602D00E3B19C /* PerformanceTests.swift */; };
 		638DCAD3200D9EC00041C75A /* UInt256+arc4random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638DCAD2200D9EC00041C75A /* UInt256+arc4random.swift */; };
@@ -87,7 +87,7 @@
 		636509E51FF859640065405F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63650A311FF85F960065405F /* UInt256.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UInt256.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		636EA8E120131E07006A60DA /* UInt256+Divide&Conquer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt256+Divide&Conquer.swift"; sourceTree = "<group>"; };
-		636F8BF6201656B800F37750 /* UInt256+BarrettDivision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt256+BarrettDivision.swift"; sourceTree = "<group>"; };
+		636F8BF6201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+BarrettDivision.swift"; sourceTree = "<group>"; };
 		637A1AC4202043C70013C247 /* UInt256Tests macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UInt256Tests macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		638DCAD2200D9EC00041C75A /* UInt256+arc4random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UInt256+arc4random.swift"; sourceTree = "<group>"; };
 		63C63F781FF9E2F00096F3CD /* UInt256Playground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = UInt256Playground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -149,7 +149,7 @@
 				63E9AE6C200014870009BE90 /* UInt256+Karatsuba.swift */,
 				636EA8E120131E07006A60DA /* UInt256+Divide&Conquer.swift */,
 				638DCAD2200D9EC00041C75A /* UInt256+arc4random.swift */,
-				636F8BF6201656B800F37750 /* UInt256+BarrettDivision.swift */,
+				636F8BF6201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift */,
 				63CA4A0520238A2300B52AF4 /* FixedWidthInteger+LongDivision.swift */,
 			);
 			path = Sources;
@@ -389,7 +389,7 @@
 				63650A001FF85AF80065405F /* UInt256+Numeric.swift in Sources */,
 				636509FF1FF85AF80065405F /* UInt256+Hashable.swift in Sources */,
 				63CA4A0620238A2300B52AF4 /* FixedWidthInteger+LongDivision.swift in Sources */,
-				636F8BF7201656B800F37750 /* UInt256+BarrettDivision.swift in Sources */,
+				636F8BF7201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift in Sources */,
 				638DCAD3200D9EC00041C75A /* UInt256+arc4random.swift in Sources */,
 				636509FE1FF85AF80065405F /* UInt256+CustomStringConvertible.swift in Sources */,
 				636509FD1FF85AF80065405F /* UInt256+UnsignedInteger.swift in Sources */,
@@ -411,7 +411,7 @@
 				63650A401FF85FE50065405F /* UInt256+Numeric.swift in Sources */,
 				63650A3F1FF85FE50065405F /* UInt256+Hashable.swift in Sources */,
 				63CA4A0720238A2300B52AF4 /* FixedWidthInteger+LongDivision.swift in Sources */,
-				636F8BF8201656B800F37750 /* UInt256+BarrettDivision.swift in Sources */,
+				636F8BF8201656B800F37750 /* FixedWidthInteger+BarrettDivision.swift in Sources */,
 				638DCAD4200D9EC00041C75A /* UInt256+arc4random.swift in Sources */,
 				63650A3E1FF85FE50065405F /* UInt256+CustomStringConvertible.swift in Sources */,
 				63650A3D1FF85FE50065405F /* UInt256+UnsignedInteger.swift in Sources */,

--- a/UInt256.xcodeproj/xcshareddata/xcbaselines/5F035E642A3DD72A9413CD89.xcbaseline/F45F2EBA-064D-4C71-9856-6FAF23B8FF72.plist
+++ b/UInt256.xcodeproj/xcshareddata/xcbaselines/5F035E642A3DD72A9413CD89.xcbaseline/F45F2EBA-064D-4C71-9856-6FAF23B8FF72.plist
@@ -16,6 +16,16 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
+			<key>testBarrettDivisionPerf64()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00166</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Feb 2, 2018, 11:03:09 PM</string>
+				</dict>
+			</dict>
 			<key>testDivisionPerformace()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
@@ -64,6 +74,16 @@
 					<real>0.046784</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Jan 19, 2018, 9:27:24 AM</string>
+				</dict>
+			</dict>
+			<key>testNativeDivisionPerf64()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0010631</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
 				</dict>
 			</dict>
 			<key>testPerformanceExample()</key>

--- a/UInt256.xcodeproj/xcshareddata/xcbaselines/637A1AC3202043C70013C247.xcbaseline/6B4A8AF6-456E-4F6E-B5DB-46F0EB2D285C.plist
+++ b/UInt256.xcodeproj/xcshareddata/xcbaselines/637A1AC3202043C70013C247.xcbaseline/6B4A8AF6-456E-4F6E-B5DB-46F0EB2D285C.plist
@@ -16,6 +16,16 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
+			<key>testBarrettDivisionPerf64()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0028968</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
 			<key>testDivideAndConquerPerf()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
@@ -52,6 +62,16 @@
 				<dict>
 					<key>baselineAverage</key>
 					<real>0.50391</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testNativeDivisionPerf64()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0014816</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>


### PR DESCRIPTION
and unsigned-integers. this could potentially pave way for UInt512, UInt1024 etc.