### PR TITLE
Update min and max in UnsignedInteger extension to support Swift 6.0

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/UInt256+UnsignedInteger.swift
+++ b/Sources/UInt256+UnsignedInteger.swift
@@ -5,7 +5,7 @@
 extension UInt256: UnsignedInteger {
     
     nonisolated(unsafe) public static var max = UInt256([UInt64.max, UInt64.max, UInt64.max, UInt64.max])
-    public static var min = UInt256([UInt64.min, UInt64.min, UInt64.min, UInt64.min])
+    nonisolated(unsafe) public static var min = UInt256([UInt64.min, UInt64.min, UInt64.min, UInt64.min])
 
     public var magnitude: UInt256 {
         return UInt256(parts)

--- a/Sources/UInt256+UnsignedInteger.swift
+++ b/Sources/UInt256+UnsignedInteger.swift
@@ -4,8 +4,8 @@
 // see: https://developer.apple.com/documentation/swift/unsignedinteger
 extension UInt256: UnsignedInteger {
     
-    nonisolated(unsafe) public static var max = UInt256([UInt64.max, UInt64.max, UInt64.max, UInt64.max])
-    nonisolated(unsafe) public static var min = UInt256([UInt64.min, UInt64.min, UInt64.min, UInt64.min])
+    public static let max = UInt256([UInt64.max, UInt64.max, UInt64.max, UInt64.max])
+    public static let min = UInt256([UInt64.min, UInt64.min, UInt64.min, UInt64.min])
 
     public var magnitude: UInt256 {
         return UInt256(parts)

--- a/Sources/UInt256+UnsignedInteger.swift
+++ b/Sources/UInt256+UnsignedInteger.swift
@@ -4,7 +4,7 @@
 // see: https://developer.apple.com/documentation/swift/unsignedinteger
 extension UInt256: UnsignedInteger {
     
-    public static var max = UInt256([UInt64.max, UInt64.max, UInt64.max, UInt64.max])
+    nonisolated(unsafe) public static var max = UInt256([UInt64.max, UInt64.max, UInt64.max, UInt64.max])
     public static var min = UInt256([UInt64.min, UInt64.min, UInt64.min, UInt64.min])
 
     public var magnitude: UInt256 {

--- a/Sources/UInt256.swift
+++ b/Sources/UInt256.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-public struct UInt256 {
+public struct UInt256: Sendable {
     var parts: [UInt64]
 
     public init() {


### PR DESCRIPTION
Added "nonisolated(unsafe)" property to min and max.